### PR TITLE
[KARLAISELA][ADD][FEATURE/CREATE-DAT]Agregar script dat.sh para mostar fecha y hora

### DIFF
--- a/dat.sh
+++ b/dat.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Limpia pantalla al iniciar
+tput clear 
+
+# Formatos con tput
+negrita=$(tput bold)
+reset=$(tput sgr0)
+
+# Colores con tput
+rojo=$(tput setaf 160)
+morado=$(tput setaf 165)
+rosita=$(tput setaf 219)
+azul=$(tput setaf 63)
+magenta=$(tput setaf 207)
+cyan=$(tput setaf 14)
+gris=$(tput setaf 247)
+
+# Animación 
+escribir_lento() {
+    local texto="$1"
+    for ((i=0; i<${#texto}; i++)); do
+        printf "%s" "${texto:$i:1}"
+        sleep 0.05
+    done
+    echo ""
+}
+
+# ASCII INFOSIS estilo terminal
+ascii_art=(
+
+
+"░▒▓███████▓▒░ ░▒▓██████▓▒░▒▓████████▓▒░" 
+"░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░ ░▒▓█▓▒░    "
+"░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░ ░▒▓█▓▒░    "
+"░▒▓█▓▒░░▒▓█▓▒░▒▓████████▓▒░ ░▒▓█▓▒░    "
+"░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░ ░▒▓█▓▒░    "
+"░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░ ░▒▓█▓▒░    "
+"░▒▓███████▓▒░░▒▓█▓▒░░▒▓█▓▒░ ░▒▓█▓▒░    "                            
+
+)
+
+# Mostrar ASCII con animación
+for linea in "${ascii_art[@]}"; do
+    printf "${cyan}%s${reset}\n" "$linea"
+    sleep 0.1
+done
+
+echo ""
+escribir_lento "${magenta}:: HORA Y FECHA ::${reset}"
+sleep 0.5
+
+
+# Obtener y mostrar la fecha y hora del RTC
+grep -E "rtc_(date|time)" /proc/driver/rtc | awk '{print $3}' | xargs echo


### PR DESCRIPTION
Este pull request incluye el archivo `dat.sh`, que es un script que muestra un arte ASCII en la terminal seguido de la hora y fecha actual obtenida del RTC.

**Resumen de todos los commits:**
- Se agregó el archivo `dat.sh`, que incluye el arte ASCII y la función para mostrar la hora y fecha.

**Razón de los commits:**
- Añadir un script útil que muestre información visual y temporal al usuario.

**Issues o tickets relacionados:**
- Ninguno en este momento.

**Pruebas realizadas:**
- Se probó el script en diferentes terminales y se verificó que el arte ASCII se muestra correctamente y que la fecha y hora se obtienen sin errores.
